### PR TITLE
Fixes for Vaprobash environment (#38)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -292,7 +292,7 @@ Vagrant.configure("2") do |config|
   ##########
 
   # Provision Composer
-  config.vm.provision "shell", path: "#{github_url}/scripts/composer.sh", privileged: false, args: composer_packages.join(" ")
+  config.vm.provision "shell", path: "#{github_url}/scripts/composer.sh", privileged: false, args: ["", composer_packages.join(" ")]
 
   # Provision Laravel
   # config.vm.provision "shell", path: "#{github_url}/scripts/laravel.sh", privileged: false, args: [server_ip, laravel_root_folder, public_folder, laravel_version]

--- a/scripts/environment.sh
+++ b/scripts/environment.sh
@@ -42,7 +42,7 @@ block="
             include fastcgi_params;
             fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
             fastcgi_param LARA_ENV local; # Environment variable for Laravel
-            fastcgi_param HTTP_PROXY ""; # Fix for https://httpoxy.org/ vulnerability
+            fastcgi_param HTTP_PROXY \"\"; # Fix for https://httpoxy.org/ vulnerability
             fastcgi_param HTTPS off;
         }
 
@@ -82,7 +82,7 @@ block="
                    text/plain \
                    text/xml;
         gzip_buffers 16 8k;
-        gzip_disable "MSIE [1-6]\.(?!.*SV1)";
+        gzip_disable \"MSIE [1-6]\.(?!.*SV1)\";
 
     }
 "


### PR DESCRIPTION
* Escape some quotes in environment.sh
* Fix incompatibility between Vaprobash 1.4.2 where first parameter for composer.sh is now treated as a Github token

Ref: https://github.com/fideloper/Vaprobash/pull/493